### PR TITLE
Enable reference genome build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 CXX=		g++
 CC=			gcc
 CXXFLAGS=	-g -O3 -msse4.2 -mpopcnt -fomit-frame-pointer -Wall
+
+# Optional reference-guided workflow
+REF_GENOME ?= 0
+ifeq ($(REF_GENOME),1)
+CXXFLAGS += -DENABLE_REF_GENOME_V4
+endif
 CFLAGS=		$(CXXFLAGS)
 CPPFLAGS=
 INCLUDES=
 OBJS=		CommandLines.o Process_Read.o Assembly.o Hash_Table.o \
 			POA.o Correct.o Levenshtein_distance.o Overlaps.o Trio.o kthread.o Purge_Dups.o \
 			htab.o hist.o sketch.o anchor.o extract.o sys.o hic.o rcut.o horder.o ecovlp.o\
-			tovlp.o inter.o kalloc.o gfa_ut.o gchain_map.o
+                       tovlp.o inter.o kalloc.o gfa_ut.o gchain_map.o ref_genome.o
 EXE=		hifiasm
 LIBS=		-lz -lpthread -lm
 
@@ -81,3 +87,5 @@ inter.o: inter.h Process_Read.h
 kalloc.o: kalloc.h
 gfa_ut.o: Overlaps.h
 gchain_map.o: gchain_map.h
+ref_genome.o: ref_genome.h Process_Read.h
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ See [tutorial][tutorial] for more details.
   - [Hi-C integration](#hic)
   - [Trio binning](#trio)
   - [Ultra-long ONT integration](#ul)
+  - [Reference-guided workflow](#refasm)
   - [Output files](#output)
 - [Results](#results)
 - [Getting Help](#help)
@@ -199,6 +200,23 @@ Hifiasm can preserve more telomeres by specifying the telomere motif using the `
 Below is an example applied to human genome assembly.
 ```sh
 hifiasm -o NA12878.asm -t32 --telo-m CCCTAA HiFi-reads.fq.gz
+```
+
+### <a name="refasm"></a>Reference-guided workflow
+
+Enable optional reference-guided alignment at build time:
+
+```sh
+make REF_GENOME=1
+```
+
+Phase A builds a reference index and Phase B maps unitigs against it:
+
+```sh
+# Phase A
+./hifiasm --ref ref.fa -o ref_work
+# Phase B
+./hifiasm --unitig-map ref_work/ref.fa unitigs.gfa
 ```
 
 ### <a name="output"></a>Output files

--- a/inter.cpp
+++ b/inter.cpp
@@ -23002,7 +23002,7 @@ ma_ug_t *ul_realignment_back(const ug_opt_t *uopt, asg_t *sg, uint32_t double_ch
  * @param uid unitig ID
  * @return 序列指针，失败返回NULL
  */
-static inline const char* ensure_unitig_seq(ma_ug_t* ug, uint32_t uid) {
+const char* ensure_unitig_seq(ma_ug_t* ug, uint32_t uid) {
     if (!ug || uid >= ug->u.n) return NULL;
 
     ma_utg_t* utg = &ug->u.a[uid];
@@ -23319,3 +23319,4 @@ int integrate_reference_blocks_to_existing_ul_pipeline(ma_ug_t *unitigs,
 }
 
 #endif // ENABLE_REF_GENOME_V4
+

--- a/ref_genome.cpp
+++ b/ref_genome.cpp
@@ -1269,3 +1269,4 @@ int ref_genome_create_summary(const ref_genome_t *ref, const char *output_file)
  * - 修正了所有编译错误
  * - 优化了性能和内存使用
  */
+

--- a/ref_genome.h
+++ b/ref_genome.h
@@ -346,3 +346,4 @@ int ref_genome_create_summary(const ref_genome_t *ref, const char *output_file);
  * - 只修复编译错误，不改变功能行为
  * - 向后兼容所有现有调用代码
  */
+


### PR DESCRIPTION
## Summary
- add optional `REF_GENOME` flag in Makefile to compile reference-guided modules
- include `ref_genome.o` in the build and list its dependencies
- fix `ensure_unitig_seq` declaration mismatch
- document reference-guided workflow in README
- append missing newlines at EOF

## Testing
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_6879f2b600e8832397cb98373a2c8eec