### PR TITLE
Implement cleanup_reference_genome_resources

### DIFF
--- a/ref_genome.cpp
+++ b/ref_genome.cpp
@@ -1274,3 +1274,13 @@ int ref_genome_create_summary(const ref_genome_t *ref, const char *output_file)
 ref_genome_t *global_ref_genome = NULL;
 #endif
 
+#ifdef ENABLE_REF_GENOME_V4
+void cleanup_reference_genome_resources(void)
+{
+    if (global_ref_genome) {
+        ref_genome_destroy(global_ref_genome);
+        global_ref_genome = NULL;
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary
- implement `cleanup_reference_genome_resources` in `ref_genome.cpp`
- wrap the implementation with `ENABLE_REF_GENOME_V4`
- ensure global reference genome is freed then nulled

## Testing
- `make -j$(nproc)` *(fails: undefined reference to various symbols)*
- `make REF_GENOME=1 -j$(nproc)` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687da46a854483238d6472c19d8de903